### PR TITLE
Use a null when serializing Response Ids equal to None

### DIFF
--- a/src/response.rs
+++ b/src/response.rs
@@ -47,7 +47,7 @@ impl<R: Serialize, E: Serialize> Serialize for Response<R, E> {
         }?;
         match self.id {
             Some(ref id) => state.serialize_entry("id", id),
-            None => state.serialize_key("id"),
+            None => state.serialize_entry("id", &()),
         }?;
 
         state.end()

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -64,3 +64,11 @@ fn success_failure_deserialize_without_id() {
     let result: Response = serde_json::from_str(text).unwrap();
     assert_eq!(result, expected);
 }
+
+#[test]
+fn success_serialize_null_id() {
+    let result = Response::result(Version::V2, serde_json::Value::from(1), None);
+
+    let serialized = serde_json::to_string(&result).unwrap();
+    assert_eq!(serialized, r#"{"jsonrpc":"2.0","result":1,"id":null}"#);
+}


### PR DESCRIPTION
Right now, when the `Response`'s `id` is set to `None`, the resulting JSON response is invalid:
```
{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id"} // note the missing value for "id"
```

With a tiny tweak, the correct response JSON is produced instead:
```
{"jsonrpc":"2.0","error":{"code":-32700,"message":"Parse error"},"id":null}
```