### PR TITLE
Deserialize version with str

### DIFF
--- a/src/id.rs
+++ b/src/id.rs
@@ -1,4 +1,4 @@
-use serde::de::{Error, MapAccess, Visitor};
+use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 type StrBuf = str_buf::StrBuf<36>;
@@ -58,13 +58,4 @@ impl<'a> Visitor<'a> for IdVisitor {
             Ok(Id::Str(res))
         }
     }
-
-    fn visit_map<E>(self, mut map: E) -> Result<Self::Value, E::Error>
-    where
-        E: MapAccess<'a>,
-    {
-        let entry: StrBuf = map.next_value()?;
-        self.visit_str(entry.as_str())
-    }
 }
-

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,5 +1,5 @@
-use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use serde::de::{Error, Visitor};
 
 type StrBuf = str_buf::StrBuf<36>;
 
@@ -59,3 +59,4 @@ impl<'a> Visitor<'a> for IdVisitor {
         }
     }
 }
+

--- a/src/id.rs
+++ b/src/id.rs
@@ -1,5 +1,5 @@
+use serde::de::{Error, MapAccess, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde::de::{Error, Visitor};
 
 type StrBuf = str_buf::StrBuf<36>;
 
@@ -57,6 +57,14 @@ impl<'a> Visitor<'a> for IdVisitor {
             }
             Ok(Id::Str(res))
         }
+    }
+
+    fn visit_map<E>(self, mut map: E) -> Result<Self::Value, E::Error>
+    where
+        E: MapAccess<'a>,
+    {
+        let entry: StrBuf = map.next_value()?;
+        self.visit_str(entry.as_str())
     }
 }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,4 +1,7 @@
+use serde::de::{Error, Visitor};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use core::fmt;
 
 ///Protocol Version
 #[derive(Debug, PartialEq, Clone, Copy, Hash, Eq)]
@@ -24,8 +27,23 @@ impl Serialize for Version {
 
 impl<'a> Deserialize<'a> for Version {
     fn deserialize<D: Deserializer<'a>>(des: D) -> Result<Self, D::Error> {
-        let text: &'a str = Deserialize::deserialize(des)?;
-        match text {
+        des.deserialize_any(VersionVisitor)
+    }
+}
+
+struct VersionVisitor;
+ 
+impl<'a> Visitor<'a> for VersionVisitor {
+    type Value = Version;
+
+    #[inline]
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("Identifier must be a string")
+    }
+
+    #[inline]
+    fn visit_str<E: Error>(self, v: &str) -> Result<Self::Value, E> {
+        match v {
             "2.0" => Ok(Version::V2),
             _ => Err(serde::de::Error::custom("Invalid version. Allowed: 2.0")),
         }

--- a/src/version.rs
+++ b/src/version.rs
@@ -27,12 +27,12 @@ impl Serialize for Version {
 
 impl<'a> Deserialize<'a> for Version {
     fn deserialize<D: Deserializer<'a>>(des: D) -> Result<Self, D::Error> {
-        des.deserialize_any(VersionVisitor)
+        des.deserialize_str(VersionVisitor)
     }
 }
 
 struct VersionVisitor;
- 
+
 impl<'a> Visitor<'a> for VersionVisitor {
     type Value = Version;
 


### PR DESCRIPTION
In the case when the deserialization is from a `serde_json::Value`, the `Value::String` as to deal with escaping. 
https://github.com/serde-rs/serde/issues/1413
