### PR TITLE
Add Error::EM type parameter with default StrBuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-types"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Douman <douman@gmx.se>"]
 edition = "2018"
 description = "Type definitions for JSON-RPC"


### PR DESCRIPTION
Fixes #5

@xentec 


This adds extra type parameter to both `Response` and `Error` with default to StrBuf.

You can substitute it with any type that implement the same traits:

```
Debug, PartialEq, Clone, Serialize, Deserialize
```

Let me know if it works for you