### PR TITLE
Parse Response when both result and error is present

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-rpc-types"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Douman <douman@gmx.se>"]
 edition = "2018"
 description = "Type definitions for JSON-RPC"

--- a/tests/response.rs
+++ b/tests/response.rs
@@ -55,7 +55,32 @@ fn response_deserialize_should_fail_on_unknown_field() {
 fn response_deserialize_should_fail_on_mixing_result_error() {
     let text = r#"{"jsonrpc":"2.0","error":{"data":"text","code":-32601,"message":"Method not found"}, "id": null, "result": 1}"#;
     let result: serde_json::Error = serde_json::from_str::<Response>(text).unwrap_err();
-    assert_eq!(result.to_string(), "JSON-RPC Response contains both result and error field at line 1 column 105");
+    assert_eq!(result.to_string(), "JSON-RPC Response contains both result and error field at line 1 column 109");
+}
+
+#[test]
+fn response_deserialize_should_succeed_with_null_result() {
+    let expected = Response::error(Version::V2, create_error(), None);
+    let text = r#"{"jsonrpc":"2.0","error":{"data":"text","code":-32601,"message":"Method not found"}, "id": null, "result": null}"#;
+    let result = serde_json::from_str::<Response>(text).unwrap();
+    assert_eq!(result, expected);
+
+    //Order matters bitch
+    let text = r#"{"jsonrpc":"2.0", "result": null, "error":{"data":"text","code":-32601,"message":"Method not found"}, "id": null}"#;
+    let result = serde_json::from_str::<Response>(text).unwrap();
+    assert_eq!(result, expected);
+}
+
+#[test]
+fn response_deserialize_should_succeed_with_null_error() {
+    let expected = Response::result(Version::V2, serde_json::Value::from(1), None);
+    let text = r#"{"jsonrpc":"2.0","error":null, "id": null, "result": 1}"#;
+    let result = serde_json::from_str::<Response>(text).unwrap();
+    assert_eq!(result, expected);
+
+    let text = r#"{"jsonrpc":"2.0","id": null, "result": 1, "error":null}"#;
+    let result = serde_json::from_str::<Response>(text).unwrap();
+    assert_eq!(result, expected);
 }
 
 #[test]
@@ -77,9 +102,11 @@ fn success_serialize_null_id() {
 
 #[test]
 fn success_deserialize_from_serde_json() {
+    type NullResponse = json_rpc_types::Response<(), serde_json::Value>;
+
     let json_str = r#"{"id":"1","jsonrpc":"2.0","result":null}"#;
     let value: serde_json::Value = serde_json::from_str(json_str).unwrap();
     println!("{:?}", value);
-    let response3: Response = serde_json::from_value(value).unwrap();
+    let response3: NullResponse = serde_json::from_value(value).unwrap();
     println!("{:?}", response3);
 }


### PR DESCRIPTION
Fixes #9

@Georges760 
Please take a look at solution
It is quite trivial aside from requiring you effectively to deserialize both error and result if they are present
But as long as one of them is NULL it will be success (with exception of special case of `()` result which I treat specially. Or actually any ZST type just for the sake of ability to deliver `result` as NULL)