### PR TITLE
let version be omitted when deserializing a request

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -19,6 +19,7 @@ use crate::id::Id;
 #[serde(deny_unknown_fields)]
 pub struct Request<P, T=StrBuf> {
     ///A String specifying the version of the JSON-RPC protocol.
+    #[serde(default)]
     pub jsonrpc: Version,
     ///A String containing the name of the method to be invoked
     ///

--- a/tests/request.rs
+++ b/tests/request.rs
@@ -58,6 +58,19 @@ fn notification_deserialize() {
 
     assert!(notification.is_notification());
     assert_eq!(expected, notification);
+
+    let text = r#"{"method":"update"}"#;
+    let notification: Request = serde_json::from_str(text).unwrap();
+
+    let expected = Request {
+        jsonrpc: Version::V2,
+        method: "update".try_into().unwrap(),
+        params: None,
+        id: None,
+    };
+
+    assert!(notification.is_notification());
+    assert_eq!(expected, notification);
 }
 
 #[test]


### PR DESCRIPTION
version is already optional on Response